### PR TITLE
Feat/implement deployment docker

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+# Description
+
+_Short introduction to main goals_
+
+## Details
+
+- _List of achivements_
+
+## Other improvements
+
+_(optional) unrelated features and other updates_
+
+## Documentation
+
+_(optional) Documentation, screenshoots, code examples, shell commands, environment variables, etc_

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build React app
+
+on:
+  pull_request:
+    branches: [main]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: "Build React portfolio"
+
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        node-version: ["20.x"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install packages
+        run: npm ci
+
+      #- name: Running tests
+      #  run: npm run test
+
+      - name: Build projet as static website
+        run: npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20.17.0-alpine3.20 AS build
+
+WORKDIR /src/app
+
+COPY package.json package-lock.json /src/app/
+
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+
+FROM httpd:2.4.62-alpine3.20
+
+COPY --from=build /src/app/build /usr/local/apache2/htdocs/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  monportfolio:
+    container_name: monportfolio
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 8081:80

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "mon-portfolio",
   "version": "0.1.0",
   "private": true,
+  "homepage": "./",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-brands-svg-icons": "^6.5.2",


### PR DESCRIPTION
# Description

Adding deployment with Docker and Docker compose example

## Details

- Add Dockerfile to build image
- Add docker-compose config to deploy locally containers

## Other improvements

- Fixing `package.json` homepage field

## Documentation

How to start container with docker-compose

Before start you need to install Docker and Docker compose locally on your machine.
See these tutorials:

- [Docker installation](https://docs.docker.com/engine/install/)
- [Docker Compose installation](https://docs.docker.com/compose/install/)

```sh
# Start containers locally and attach terminal to logs
docker compose up

# Start containers locally as dettached (background process)
docker compose up -d

# Remove and shutdown gracefully containers
docker compose down
```
